### PR TITLE
Support comments and Obsidian markdown table format

### DIFF
--- a/lib/parameterized_test.ex
+++ b/lib/parameterized_test.ex
@@ -215,7 +215,7 @@ defmodule ParameterizedTest do
       |> Enum.map(&String.to_atom/1)
 
     rows
-    |> Enum.reject(&separator_row?/1)
+    |> Enum.reject(&separator_or_comment_row?/1)
     |> Enum.map(fn row ->
       cells =
         row
@@ -282,9 +282,11 @@ defmodule ParameterizedTest do
   end
 
   # A regex to match rows consisting of pipes separated by hyphens, like |------|-----|
-  @separator_regex ~r/^\|(-+\|)+$/
+  @separator_regex ~r/^\|( ?-+ ?\|)+$/
 
-  defp separator_row?(row) do
+  defp separator_or_comment_row?("#" <> _), do: true
+
+  defp separator_or_comment_row?(row) do
     Regex.match?(@separator_regex, row)
   end
 

--- a/test/parameterized_test_test.exs
+++ b/test/parameterized_test_test.exs
@@ -43,6 +43,40 @@ defmodule ParameterizedTestTest do
       assert free_shipping? == gets_free_shipping?
     end
 
+    param_test "ignores commented lines",
+               """
+               | spending_by_category          | coupon      | gets_free_shipping? |
+               |-------------------------------|-------------|---------------------|
+               # Temporarily disable
+               #| %{shoes: 19_99, pants: 29_99} |             | false               |
+               | %{shoes: 59_99, pants: 49_99} |             | true                |
+               """,
+               %{
+                 spending_by_category: spending_by_category,
+                 coupon: coupon,
+                 gets_free_shipping?: gets_free_shipping?
+               } do
+      shipping_cost = ExampleShippingCalculator.calculate_shipping(spending_by_category, coupon)
+      free_shipping? = shipping_cost == 0
+      assert free_shipping? == gets_free_shipping?
+    end
+
+    param_test "supports obsidian-flavored markdown table separator rows",
+               """
+               | spending_by_category          | coupon      | gets_free_shipping? |
+               | ----------------------------- | ----------- | ------------------- |
+               | %{shoes: 59_99, pants: 49_99} |             | true                |
+               """,
+               %{
+                 spending_by_category: spending_by_category,
+                 coupon: coupon,
+                 gets_free_shipping?: gets_free_shipping?
+               } do
+      shipping_cost = ExampleShippingCalculator.calculate_shipping(spending_by_category, coupon)
+      free_shipping? = shipping_cost == 0
+      assert free_shipping? == gets_free_shipping?
+    end
+
     param_test "supports Markdown files as input",
                "test/fixtures/params.md",
                %{


### PR DESCRIPTION
Fixes #15

Obsidian formats markdown tables with a space between the `|` characters. Also comments are very helpful when debugging or to provide additional detail to the table.