### PR TITLE
Mix formatter plugin for sigils

### DIFF
--- a/lib/parameterized_test/formatter.ex
+++ b/lib/parameterized_test/formatter.ex
@@ -2,12 +2,14 @@ defmodule ParameterizedTest.Formatter do
   @moduledoc false
   @behaviour Mix.Tasks.Format
 
+  @impl Mix.Tasks.Format
   def features(_opts) do
     sigil = if Version.match?(System.version(), "< 1.15.0"), do: :x, else: :PARAMS
 
     [sigils: [sigil], extensions: []]
   end
 
+  @impl Mix.Tasks.Format
   def format(contents, _opts) do
     contents
     |> ParameterizedTest.Parser.example_table_ast()

--- a/lib/parameterized_test/formatter.ex
+++ b/lib/parameterized_test/formatter.ex
@@ -1,0 +1,59 @@
+defmodule ParameterizedTest.Formatter do
+  @moduledoc false
+  @behaviour Mix.Tasks.Format
+
+  def features(_opts) do
+    sigil = if Version.match?(System.version(), "< 1.15.0"), do: :x, else: :PARAMS
+
+    [sigils: [sigil], extensions: []]
+  end
+
+  def format(contents, _opts) do
+    contents
+    |> ParameterizedTest.Parser.example_table_ast()
+    |> format_table()
+  end
+
+  defp format_table(rows) do
+    [header | _] =
+      table_cells =
+      rows
+      |> Enum.filter(&match?({:cells, _}, &1))
+      |> Enum.map(&elem(&1, 1))
+
+    column_widths =
+      Enum.reduce(table_cells, List.duplicate(0, length(header)), fn row_cells, acc ->
+        row_cells
+        |> Enum.map(&String.length/1)
+        |> Enum.zip(acc)
+        |> Enum.map(fn {a, b} -> max(a, b) end)
+      end)
+
+    Enum.map_join(rows, "\n", &format_row(&1, column_widths)) <> "\n"
+  end
+
+  defp format_row({:comment, c}, _widths), do: c
+
+  defp format_row({:separator, pad_type}, widths) do
+    padding =
+      case pad_type do
+        :padded -> " "
+        :unpadded -> "-"
+      end
+
+    widths
+    |> Enum.map_join("|", fn w ->
+      [padding, String.duplicate("-", w), padding]
+    end)
+    |> borders()
+  end
+
+  defp format_row({:cells, cells}, widths) do
+    cells
+    |> Enum.zip(widths)
+    |> Enum.map_join("|", fn {cell, w} -> " #{String.pad_trailing(cell, w)} " end)
+    |> borders()
+  end
+
+  defp borders(str), do: "|#{str}|"
+end

--- a/lib/parameterized_test/parser.ex
+++ b/lib/parameterized_test/parser.ex
@@ -69,7 +69,7 @@ defmodule ParameterizedTest.Parser do
     table
     |> String.split("\n", trim: true)
     |> Enum.map(&String.trim/1)
-    |> sigil_ast_rows(context)
+    |> table_ast_rows(context)
   end
 
   defp description(%{test_description: desc}), do: desc
@@ -181,13 +181,13 @@ defmodule ParameterizedTest.Parser do
     end
   end
 
-  defp sigil_ast_rows([header | _] = all_rows, context) do
+  defp table_ast_rows([header | _] = all_rows, context) do
     headers = split_cells(header)
 
     Enum.map(all_rows, fn row ->
       row
       |> classify_row()
-      |> rare_parse_row()
+      |> ast_parse_row()
       |> tap(fn
         {:cells, cells} -> check_cell_count(cells, headers, row, context)
         _ -> nil
@@ -206,10 +206,10 @@ defmodule ParameterizedTest.Parser do
     {type, row}
   end
 
-  defp rare_parse_row({:cells, row}), do: {:cells, split_cells(row)}
-  defp rare_parse_row({:comment, _} = row), do: row
+  defp ast_parse_row({:cells, row}), do: {:cells, split_cells(row)}
+  defp ast_parse_row({:comment, _} = row), do: row
 
-  defp rare_parse_row({:separator, row}) do
+  defp ast_parse_row({:separator, row}) do
     padding = if String.contains?(row, " "), do: :padded, else: :unpadded
     {:separator, padding}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -29,6 +29,7 @@ defmodule ParameterizedTest.MixProject do
       ],
       dialyzer: [
         ignore_warnings: ".dialyzer_ignore.exs",
+        plt_add_apps: [:mix],
         plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
         flags: [
           :error_handling,

--- a/test/parameterized_test/formatter_test.exs
+++ b/test/parameterized_test/formatter_test.exs
@@ -1,0 +1,77 @@
+defmodule ParameterizedTest.FormatterTest do
+  use ExUnit.Case, async: true
+
+  describe "format/2" do
+    test "formats a table" do
+      input =
+        """
+        |a|b|
+        | - | - |
+        |"string"|:atom|
+        |123|%{d: [1.0]}|
+        # comment
+        | | "" |
+        """
+
+      expected_output =
+        """
+        | a        | b           |
+        | -------- | ----------- |
+        | "string" | :atom       |
+        | 123      | %{d: [1.0]} |
+        # comment
+        |          | ""          |
+        """
+
+      assert ParameterizedTest.Formatter.format(input, []) == expected_output
+    end
+
+    test "respects unpadded separator rows" do
+      input =
+        """
+        |a|b|
+        |-|-|
+        |"string"|:atom|
+        |123|%{d: [1.0]}|
+        # comment
+        | | "" |
+        """
+
+      expected_output =
+        """
+        | a        | b           |
+        |----------|-------------|
+        | "string" | :atom       |
+        | 123      | %{d: [1.0]} |
+        # comment
+        |          | ""          |
+        """
+
+      assert ParameterizedTest.Formatter.format(input, []) == expected_output
+    end
+
+    test "works when the table is too wide also" do
+      input =
+        """
+        | a        | b        |
+        |---------------|-------------|
+        | "string" | :atom  |
+        | 123      | %{d: [1.0]} |
+        # comment
+        |          | ""       |
+        """
+
+      expected_output =
+        """
+        | a        | b           |
+        |----------|-------------|
+        | "string" | :atom       |
+        | 123      | %{d: [1.0]} |
+        # comment
+        |          | ""          |
+        """
+
+      assert ParameterizedTest.Formatter.format(input, []) == expected_output
+    end
+  end
+end

--- a/test/parameterized_test/parser_test.exs
+++ b/test/parameterized_test/parser_test.exs
@@ -8,4 +8,24 @@ defmodule ParameterizedTest.ParserTest do
       end
     end
   end
+
+  describe "example_table_ast/1" do
+    test "returns a representation of the raw values in an example table" do
+      assert ParameterizedTest.Parser.example_table_ast("""
+             | a        | b           |
+             |----------|-------------|
+             | "string" | :atom       |
+             # comment
+             | 123      | %{d: [1.0]} |
+             |          | ""          |
+             """) == [
+               {:cells, ["a", "b"]},
+               {:separator, :unpadded},
+               {:cells, ["\"string\"", ":atom"]},
+               {:comment, "# comment"},
+               {:cells, ["123", "%{d: [1.0]}"]},
+               {:cells, ["", "\"\""]}
+             ]
+    end
+  end
 end


### PR DESCRIPTION
Adds autoformatting to the `~x` and `~PARAMS` sigils. 

To enable this in your project, you'll need to add

```elixir
# .formatter.exs
plugins: [ParameterizedTest.Formatter],
```

![CleanShot 2024-11-14 at 10 21 50](https://github.com/user-attachments/assets/bc4ceee0-1f6b-4802-87c0-02995f335ac5)

