### PR TITLE
Fix parameterized tests sometimes being skipped when running `mix test --failed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.5.0
+
+- New Mix formatter plugin for formatting the package's sigils, courtesy of @rschenk (🎉). To enable it, in your `formatter.exs`, add to following:
+    ```elixir
+      plugins: [
+        ParameterizedTest.Formatter,
+      ],
+    ```
+You can see a brief video demo [on the PR](https://github.com/s3cur3/parameterized_test/pull/32).
+- Fixed an issue (#31) where `mix test --failed` could fail to run previously-failing tests because the way we were adding the parameters to the name (as a map) was not stable across runs. The consequence of this change is that the names of tests missing a description will change from listing parameters as maps to lists.
+    - Example: suppose you previously have a `param_test` called `"checks equality"` with parameters `val_1: :a` and `val_b: :b`. It would previously have been given the full name `"checks equality (%{val_1: :a, val_2: :b})"` *or* `"checks equality (%{val_2: :b, val_1: :a})"`, and which you saw would change between test runs. In this release, it will consistently be given the name `"checks equality ([val_1: :a, val_2: :b])"`.
+
 ## v0.4.0
 
 - Adds a new `param_feature` macro, which wraps Wallaby's `feature` tests

--- a/README.md
+++ b/README.md
@@ -263,13 +263,13 @@ end
 
 Under the hood, this produces two tests with the names:
 
-- `"checks equality (%{val_1: :a, val_b: :a})"`
-- `"checks equality (%{val_1: :b, val_b: :c})"`
+- `"checks equality ([val_1: :a, val_b: :a])"`
+- `"checks equality ([val_1: :b, val_b: :c])"`
 
 And if you ran this test, you'd get an error that looks like this:
 
 ```
-  1) test checks equality (%{val_1: :b, val_2: :c}) (MyModuleTest)
+  1) test checks equality ([val_1: :b, val_2: :c]) (MyModuleTest)
      test/my_module_test.exs:4
      Assertion with == failed
      code:  assert val_1 == val_2

--- a/lib/parameterized_test/parser.ex
+++ b/lib/parameterized_test/parser.ex
@@ -72,6 +72,12 @@ defmodule ParameterizedTest.Parser do
     |> table_ast_rows(context)
   end
 
+  defp description(kw_list) when is_list(kw_list) do
+    kw_list
+    |> Map.new()
+    |> description()
+  end
+
   defp description(%{test_description: desc}), do: desc
   defp description(%{test_desc: desc}), do: desc
   defp description(%{description: desc}), do: desc
@@ -79,9 +85,9 @@ defmodule ParameterizedTest.Parser do
   defp description(_), do: nil
 
   defp parse_hand_rolled_table(evaled_table, context) do
-    parsed_table = Enum.map(evaled_table, &Map.new/1)
+    parsed_table = Enum.map(evaled_table, &Keyword.new/1)
 
-    keys = MapSet.new(parsed_table, &Map.keys/1)
+    keys = MapSet.new(parsed_table, &Keyword.keys/1)
 
     if MapSet.size(keys) > 1 do
       raise """
@@ -127,11 +133,9 @@ defmodule ParameterizedTest.Parser do
 
       check_cell_count(cells, headers, row, context)
 
-      headers
-      |> Enum.zip(cells)
-      |> Map.new()
+      Enum.zip(headers, cells)
     end)
-    |> Enum.reject(&(&1 == %{}))
+    |> Enum.reject(&Enum.empty?/1)
   end
 
   defp parse_csv_rows(rows, context)
@@ -146,11 +150,9 @@ defmodule ParameterizedTest.Parser do
 
       check_cell_count(cells, headers, row, context)
 
-      headers
-      |> Enum.zip(cells)
-      |> Map.new()
+      Enum.zip(headers, cells)
     end)
-    |> Enum.reject(&(&1 == %{}))
+    |> Enum.reject(&Enum.empty?/1)
   end
 
   defp eval_cell(cell, row, _context) do

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule ParameterizedTest.MixProject do
   def project do
     [
       app: :parameterized_test,
-      version: "0.4.0",
+      version: "0.5.0",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/parameterized_test/sigil_v114.exs
+++ b/test/parameterized_test/sigil_v114.exs
@@ -14,12 +14,12 @@ defmodule ParameterizedTest.SigilTest do
              | :standard | :editor         | "tuesdays only" |
              | :standard | :view_only      | false           |
            """ == [
-             %{plan: :free, user_permission: :admin, can_invite?: true},
-             %{plan: :free, user_permission: :editor, can_invite?: "maybe"},
-             %{plan: :free, user_permission: :view_only, can_invite?: false},
-             %{plan: :standard, user_permission: :admin, can_invite?: true},
-             %{plan: :standard, user_permission: :editor, can_invite?: "tuesdays only"},
-             %{plan: :standard, user_permission: :view_only, can_invite?: false}
+             [plan: :free, user_permission: :admin, can_invite?: true],
+             [plan: :free, user_permission: :editor, can_invite?: "maybe"],
+             [plan: :free, user_permission: :view_only, can_invite?: false],
+             [plan: :standard, user_permission: :admin, can_invite?: true],
+             [plan: :standard, user_permission: :editor, can_invite?: "tuesdays only"],
+             [plan: :standard, user_permission: :view_only, can_invite?: false]
            ]
   end
 
@@ -30,8 +30,8 @@ defmodule ParameterizedTest.SigilTest do
              | :free     | :admin          | true            |
              | :free     | :editor         | "maybe"         |
            """ == [
-             %{plan: :free, user_permission: :admin, can_invite?: true},
-             %{plan: :free, user_permission: :editor, can_invite?: "maybe"}
+             [plan: :free, user_permission: :admin, can_invite?: true],
+             [plan: :free, user_permission: :editor, can_invite?: "maybe"]
            ]
   end
 
@@ -40,7 +40,7 @@ defmodule ParameterizedTest.SigilTest do
              | string               | integer    | keyword_list            |
              | String.upcase("foo") | div(17, 4) | [foo: :bar, baz: :bang] |
            """ == [
-             %{string: "FOO", integer: 4, keyword_list: [foo: :bar, baz: :bang]}
+             [string: "FOO", integer: 4, keyword_list: [foo: :bar, baz: :bang]]
            ]
   end
 

--- a/test/parameterized_test/sigil_v115.exs
+++ b/test/parameterized_test/sigil_v115.exs
@@ -14,12 +14,12 @@ defmodule ParameterizedTest.SigilTest do
              | :standard | :editor         | "tuesdays only" |
              | :standard | :view_only      | false           |
            """ == [
-             %{plan: :free, user_permission: :admin, can_invite?: true},
-             %{plan: :free, user_permission: :editor, can_invite?: "maybe"},
-             %{plan: :free, user_permission: :view_only, can_invite?: false},
-             %{plan: :standard, user_permission: :admin, can_invite?: true},
-             %{plan: :standard, user_permission: :editor, can_invite?: "tuesdays only"},
-             %{plan: :standard, user_permission: :view_only, can_invite?: false}
+             [plan: :free, user_permission: :admin, can_invite?: true],
+             [plan: :free, user_permission: :editor, can_invite?: "maybe"],
+             [plan: :free, user_permission: :view_only, can_invite?: false],
+             [plan: :standard, user_permission: :admin, can_invite?: true],
+             [plan: :standard, user_permission: :editor, can_invite?: "tuesdays only"],
+             [plan: :standard, user_permission: :view_only, can_invite?: false]
            ]
   end
 
@@ -30,8 +30,8 @@ defmodule ParameterizedTest.SigilTest do
              | :free     | :admin          | true            |
              | :free     | :editor         | "maybe"         |
            """ == [
-             %{plan: :free, user_permission: :admin, can_invite?: true},
-             %{plan: :free, user_permission: :editor, can_invite?: "maybe"}
+             [plan: :free, user_permission: :admin, can_invite?: true],
+             [plan: :free, user_permission: :editor, can_invite?: "maybe"]
            ]
   end
 
@@ -40,7 +40,7 @@ defmodule ParameterizedTest.SigilTest do
              | string               | integer    | keyword_list            |
              | String.upcase("foo") | div(17, 4) | [foo: :bar, baz: :bang] |
            """ == [
-             %{string: "FOO", integer: 4, keyword_list: [foo: :bar, baz: :bang]}
+             [string: "FOO", integer: 4, keyword_list: [foo: :bar, baz: :bang]]
            ]
   end
 

--- a/test/parameterized_test_test.exs
+++ b/test/parameterized_test_test.exs
@@ -201,8 +201,8 @@ defmodule ParameterizedTestTest do
 
         3 ->
           assert ex_unit_test_name in [
-                   :"test user-provided description is supported (%{value: 3, test_description: nil})",
-                   :"test user-provided description is supported (%{test_description: nil, value: 3})"
+                   :"test user-provided description is supported ([value: 3, test_description: nil])",
+                   :"test user-provided description is supported ([test_description: nil, value: 3])"
                  ]
       end
     end
@@ -224,8 +224,8 @@ defmodule ParameterizedTestTest do
 
         3 ->
           assert ex_unit_test_name in [
-                   :"test user-provided description is supported as test_desc (%{value: 3, test_desc: nil})",
-                   :"test user-provided description is supported as test_desc (%{test_desc: nil, value: 3})"
+                   :"test user-provided description is supported as test_desc ([value: 3, test_desc: nil])",
+                   :"test user-provided description is supported as test_desc ([test_desc: nil, value: 3])"
                  ]
       end
     end


### PR DESCRIPTION
This applies consistent names to tests lacking a description. It accounts for the unstable ordering of maps, which was previously causing individual test names to change between test runs.

Also preps the changelog to release v0.5.0.

Resolves #31 