### PR TITLE
Support `@tag`s applied to the param_test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1
+
+- [Support `@tag` module attributes applied to `param_test` or `param_feature` blocks](https://github.com/s3cur3/parameterized_test/pull/40)
+
 ## v0.5.0
 
 - New Mix formatter plugin for formatting the package's sigils, courtesy of @rschenk (🎉). To enable it, in your `formatter.exs`, add to following:

--- a/test/parameterized_test_test.exs
+++ b/test/parameterized_test_test.exs
@@ -345,4 +345,15 @@ defmodule ParameterizedTestTest do
     |> visit(url)
     |> assert_has(Wallaby.Query.text(text, minimum: 1))
   end
+
+  @tag skip: true
+  param_test "applies tags to all parameterized tests",
+             """
+             | text     | url                  |
+             |----------|----------------------|
+             | "GitHub" | "https://github.com" |
+             | "Google" | "https://google.com" |
+             """ do
+    flunk("This test should not run")
+  end
 end


### PR DESCRIPTION
This ensures that `@tag` module attributes that are applied to a `param_test` or `param_feature` get applied to *every* test within that block, rather than just the first one.

Resolves #39